### PR TITLE
Adds endif to the control flow keywords

### DIFF
--- a/MZN.YAML-tmLanguage
+++ b/MZN.YAML-tmLanguage
@@ -41,7 +41,7 @@ patterns:
 
 ## Flow control keywords
 - name: keyword.control.mzn
-  match: \b(for|forall|if|then|else|where)\b
+  match: \b(for|forall|if|then|else|endif|where)\b
 
 ## Built-in functions
 - name: entity.name.function.mzn

--- a/MZN.tmLanguage
+++ b/MZN.tmLanguage
@@ -51,7 +51,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(for|forall|if|then|else|where)\b</string>
+			<string>\b(for|forall|if|then|else|endif|where)\b</string>
 			<key>name</key>
 			<string>keyword.control.mzn</string>
 		</dict>


### PR DESCRIPTION
In the if-then-else control structure of MiniZinc uses `endif`, this keyword, however, seemed to be missing in the language file. This means that `endif` isn't highlighted correctly. This small fix will add it to the control flow keywords as defined in the language files.
